### PR TITLE
Fix URL parsing logic to unquote %

### DIFF
--- a/src/omerocrate/uploader.py
+++ b/src/omerocrate/uploader.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass
 import importlib.util
 import logging
 from pathlib import Path
-from time import sleep
 from typing import Any, Iterable, Literal, cast, AsyncIterable
 from rdflib import Graph, URIRef
 from rdflib.query import ResultRow
@@ -12,17 +10,17 @@ from functools import cached_property
 from omero import model, gateway, grid, cmd
 from omero.model import enums
 from omero.rtypes import rstring, rbool
-from urllib.parse import urlparse
 import asyncio
 from typing_extensions import Self
 from pydantic import BaseModel, model_validator
 
-from omerocrate.utils import user_in_group
+from omerocrate.utils import uri_to_path, user_in_group
 
 logger = logging.getLogger(__name__)
 
 Namespaces = dict[str, URIRef]
 Variables = dict[str, Identifier]
+
 
 
 class SegmentationUploader(BaseModel, arbitrary_types_allowed=True):
@@ -222,7 +220,7 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
             }
         """):
             file_path = result['file_path']
-            yield file_path, Path(urlparse(file_path).path)
+            yield file_path, uri_to_path(file_path)
 
     def find_existing_images(self, image_list: list[Identifier]) -> Iterable[tuple[Identifier, int]]:
         """
@@ -266,7 +264,7 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
                     ?segmentation_file omerocrate:segmentationFor ?image_path .
                 }
             """, variables={"image_path": image_uri})
-            return Path(urlparse(result['segmentation_file']).path)
+            return uri_to_path(result['segmentation_file'])
         except ValueError:
             return None
 
@@ -319,12 +317,6 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
 
     def add_image_to_dataset(self, dataset: gateway.DatasetWrapper, image: gateway.ImageWrapper) -> None:
         dataset._linkObject(image, "DatasetImageLinkI")
-
-    def path_from_image_result(self, result: ResultRow) -> Path:
-        """
-        Converts a SPARQL result row to a Path object.
-        """
-        return Path(urlparse(result['file_path']).path)
 
     def process_image(self, uri: URIRef, image: gateway.ImageWrapper) -> None:
         """

--- a/src/omerocrate/utils.py
+++ b/src/omerocrate/utils.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from omero.gateway import DatasetWrapper, ExperimenterGroupWrapper, ExperimenterWrapper, ProxyObjectWrapper
+from urllib.parse import urlsplit, unquote
 
 def delete_dataset(dataset: DatasetWrapper):
     """
@@ -12,3 +14,11 @@ def user_in_group(user: ExperimenterWrapper, group: ExperimenterGroupWrapper, ad
     """
     return user.getId() in {user.id.val for user in admin_service.containedExperimenters(group.getId())}
     
+def uri_to_path(uri: str) -> Path:
+    """
+    Convert a URI to a file path, checking that the scheme is 'file', and unquoting any percent-encoded characters.
+    """
+    parsed = urlsplit(uri)
+    if parsed.scheme != "file":
+        raise ValueError(f"URI scheme must be 'file', got '{parsed.scheme}'")
+    return Path(unquote(parsed.path))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+from omerocrate.utils import uri_to_path
+
+
+def test_uri_to_path_valid_file_uri():
+    uri = "file:///home/user/data/image.tif"
+    result = uri_to_path(uri)
+    assert result == Path("/home/user/data/image.tif")
+
+
+def test_uri_to_path_percent_encoded():
+    uri = "file:///home/user/my%20data/image%2B1.tif"
+    result = uri_to_path(uri)
+    assert result == Path("/home/user/my data/image+1.tif")
+
+
+def test_uri_to_path_invalid_scheme_raises():
+    uri = "https://example.com/image.tif"
+    with pytest.raises(ValueError, match="URI scheme must be 'file'"):
+        uri_to_path(uri)


### PR DESCRIPTION
If there are spaces in the file name currently, this gets %-encoded, meaning that downstream tools break.