### PR TITLE
Add group permission customization

### DIFF
--- a/src/omerocrate/uploader.py
+++ b/src/omerocrate/uploader.py
@@ -26,8 +26,8 @@ class OmeroPermissions(str, Enum):
     """
     Built-in OMERO permissions categories
     """
-    # Derive from the OMERO GUI
-    # Seems to a compose of Owner + Group + Other
+    # Derived from the OMERO GUI
+    # Seems to be composed of Owner + Group + Other sections.
     # Each section is `r-` for read only, `rw` for read and write, or `ra` for read and annotate
     Private = "rw----"
     ReadOnly = "rwr---"
@@ -387,7 +387,7 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
         This may be overridden by child classes
         """
         # TODO: allow configuration via the metadata
-        return OmeroPermissions.ReadOnly
+        return OmeroPermissions.ReadAnnotate
 
     async def make_group(self) -> gateway.ExperimenterGroupWrapper:
         """

--- a/src/omerocrate/uploader.py
+++ b/src/omerocrate/uploader.py
@@ -13,6 +13,7 @@ from omero.rtypes import rstring, rbool
 import asyncio
 from typing_extensions import Self
 from pydantic import BaseModel, model_validator
+from enum import Enum
 
 from omerocrate.utils import uri_to_path, user_in_group
 
@@ -21,6 +22,17 @@ logger = logging.getLogger(__name__)
 Namespaces = dict[str, URIRef]
 Variables = dict[str, Identifier]
 
+class OmeroPermissions(str, Enum):
+    """
+    Built-in OMERO permissions categories
+    """
+    # Derive from the OMERO GUI
+    # Seems to a compose of Owner + Group + Other
+    # Each section is `r-` for read only, `rw` for read and write, or `ra` for read and annotate
+    Private = "rw----"
+    ReadOnly = "rwr---"
+    ReadAnnotate = "rwra--"
+    ReadWrite = "rwrw--"
 
 
 class SegmentationUploader(BaseModel, arbitrary_types_allowed=True):
@@ -366,6 +378,17 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
             """, variables={"root": self.root_dataset_id})
             return str(result['name'])
 
+    def get_group_perms(self) -> OmeroPermissions:
+        """
+        Specifies the permissions to set for the experimenter group.
+        This will control who can use the uploaded data.
+        It likely does not make sense to set to Private, since this would mean that only the uploader can access the data.
+        Hence, the default is ReadOnly, which allows users in the same group to view the data, but not edit it.
+        This may be overridden by child classes
+        """
+        # TODO: allow configuration via the metadata
+        return OmeroPermissions.ReadOnly
+
     async def make_group(self) -> gateway.ExperimenterGroupWrapper:
         """
         Creates the OMERO experimenter group that corresponds to this crate.
@@ -385,7 +408,8 @@ class OmeroUploader(BaseModel, arbitrary_types_allowed=True):
             group_id = self.conn.createGroup(
                 name=group_name,
                 member_Ids=[self.conn.getUser().getId()],
-                ldap=False
+                ldap=False,
+                perms=self.get_group_perms().value
             )
             return self.conn.getObject("ExperimenterGroup", group_id)
 

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 import pytest
-from omerocrate.uploader import ApiUploader, OmeroUploader
+from omerocrate.uploader import ApiUploader, OmeroUploader, OmeroPermissions
 from omerocrate.taskqueue.upload import TaskqueueUploader
 from omero.gateway import BlitzGateway
-from util import check_art_dataset, requires_flower
+from util import check_art_dataset, get_dataset_permissions, requires_flower
 
 
 @pytest.mark.parametrize("Uploader", [
@@ -19,7 +19,33 @@ async def test_upload_api(abstract_crate: Path, connection: BlitzGateway,
         segmentation_uploader=None
     )
     dataset = await uploader.execute()
+    permissions = get_dataset_permissions(dataset)
+    assert str(permissions) == "rwr---"
     check_art_dataset(dataset)
     # Test twice to ensure that the tests work with an existing group
     dataset = await uploader.execute()
     check_art_dataset(dataset)
+
+
+class ReadAnnotateUploader(ApiUploader):
+    def get_group_perms(self) -> OmeroPermissions:
+        return OmeroPermissions.ReadAnnotate
+
+    def get_group_name(self) -> str:
+        return "Abstract art (ReadAnnotate)"
+
+
+@pytest.mark.asyncio
+async def test_upload_readannotate(abstract_crate: Path, connection: BlitzGateway):
+    """
+    Test that a custom uploader can set the group permissions to ReadAnnotate
+    """
+    uploader = ReadAnnotateUploader(
+        conn=connection,
+        crate=abstract_crate,
+        segmentation_uploader=None
+    )
+    dataset = await uploader.execute()
+    check_art_dataset(dataset)
+    permissions = get_dataset_permissions(dataset)
+    assert str(permissions) == "rwra--"

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -20,27 +20,27 @@ async def test_upload_api(abstract_crate: Path, connection: BlitzGateway,
     )
     dataset = await uploader.execute()
     permissions = get_dataset_permissions(dataset)
-    assert str(permissions) == "rwr---"
+    assert str(permissions) == "rwra--"
     check_art_dataset(dataset)
     # Test twice to ensure that the tests work with an existing group
     dataset = await uploader.execute()
     check_art_dataset(dataset)
 
 
-class ReadAnnotateUploader(ApiUploader):
+class ReadWriteUploader(ApiUploader):
     def get_group_perms(self) -> OmeroPermissions:
-        return OmeroPermissions.ReadAnnotate
+        return OmeroPermissions.ReadWrite
 
     def get_group_name(self) -> str:
-        return "Abstract art (ReadAnnotate)"
+        return "Abstract art (ReadWrite)"
 
 
 @pytest.mark.asyncio
-async def test_upload_readannotate(abstract_crate: Path, connection: BlitzGateway):
+async def test_upload_readwrite(abstract_crate: Path, connection: BlitzGateway):
     """
-    Test that a custom uploader can set the group permissions to ReadAnnotate
+    Test that a custom uploader can set the group permissions to ReadWrite
     """
-    uploader = ReadAnnotateUploader(
+    uploader = ReadWriteUploader(
         conn=connection,
         crate=abstract_crate,
         segmentation_uploader=None
@@ -48,4 +48,4 @@ async def test_upload_readannotate(abstract_crate: Path, connection: BlitzGatewa
     dataset = await uploader.execute()
     check_art_dataset(dataset)
     permissions = get_dataset_permissions(dataset)
-    assert str(permissions) == "rwra--"
+    assert str(permissions) == "rwrw--"

--- a/test/util.py
+++ b/test/util.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
-from omero.gateway import DatasetWrapper
+from omero.gateway import BlitzObjectWrapper, DatasetWrapper, BlitzGateway, ExperimenterGroupWrapper
 import pytest
 from omerocrate.utils import delete_dataset
-from omero.gateway import BlitzGateway
+from omerocrate.uploader import OmeroPermissions
 from dotenv import get_key
+from omero_model_PermissionsI import PermissionsI
 
 def check_art_dataset(dataset: DatasetWrapper):
     """
@@ -17,6 +18,8 @@ def check_art_dataset(dataset: DatasetWrapper):
         assert "Color Study" in image.name
     delete_dataset(dataset)
 
+def get_dataset_permissions(wrapper: BlitzObjectWrapper) -> PermissionsI:
+    return wrapper.getDetails().getGroup().getDetails().getPermissions()
 
 def check_seg_dataset(dataset: DatasetWrapper, conn: BlitzGateway, check_rois: bool = False,
                       n_rois_expected: int = 0):


### PR DESCRIPTION
It turns out a private OMERO group is not that useful.

The build is failing, but that's a separate issue (#26).

I've tested this informally and it seems to work okay.